### PR TITLE
Fix(#66): 액세스 토큰 갱신 로직 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,9 +6,6 @@ import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useAuth } from '@/hooks/useAuth';
 
-import { apiClient } from '@/lib/apiClient';
-
-
 export default function Header() {
   const pathname = usePathname();
   const { user, isAuthenticated } = useAuthStore();
@@ -16,14 +13,6 @@ export default function Header() {
   
   // 로그인 상태 확인용 state
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    apiClient.checkAuth()
-
-    const interval = setInterval(() => {
-      apiClient.checkAuth();
-    }, 3600000); // 1시간마다 인증 유효성 검사
-  }, []);
 
   return (
     <nav className="border-b bg-blue-900 text-white fixed top-0 left-0 right-0 z-50">

--- a/src/lib/tokenUtils.ts
+++ b/src/lib/tokenUtils.ts
@@ -19,7 +19,7 @@ export const tokenUtils = {
     },
     
     // 토큰 유효성 검사 함수(기간)
-    isTokenValie: () => {
+    isAccessTokenValid: () => {
       const token = tokenUtils.returnTokens().accessToken;
       if (!token) return false;
     
@@ -31,4 +31,17 @@ export const tokenUtils = {
         return false;
       }
     },
+
+    isRefreshTokenValid: () => {
+      const token = tokenUtils.returnTokens().refreshToken;
+      if(!token) return false;
+
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        const isExpired = payload.exp * 1000 < Date.now();
+        return !isExpired;
+      } catch (error) {
+        return false;
+      }
+    }
 }


### PR DESCRIPTION
- refreshToken이 완료 되기 전에 로그인 page로 강제 리다이렉트 -> 무한 새로고침 오류 발생
- 1시간마다 토큰의 유효성 검사하는 것을 api 호출 시에 유효성 검사하는 로직으로 변경
- setInterval() 함수를 사용하지 않음으로써 메모리 누수 방지 -> 기존 header component에서 지속적으로 setInterval()함수 사용, 제대로 clean up 되지 않음
- 불필요한 메모리 사용 감소 및 refresh 완료 여부 판단으로 무한 새로고침 오류 수정