### PR TITLE
Fix(#61): API호출 최적화

### DIFF
--- a/src/app/investments/transaction-history/page.tsx
+++ b/src/app/investments/transaction-history/page.tsx
@@ -7,7 +7,6 @@ import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import MarketListCompoenet from "@/components/MarketListComponent";
-import { apiClient } from "@/lib/apiClient";
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css'
 import {ko} from "date-fns/locale"
@@ -32,7 +31,7 @@ export default function TransactionHistoryPage() {
   const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([new Date(), new Date()]);
   const [calenderStart, calenderEnd] = dateRange;
   const { tickers, markets } = useMarketStore();
-  const { tradeHistory: allTradeHistory, fetchTradeHistory } = useAssetStore();
+  const { tradeHistory: allTradeHistory } = useAssetStore();
   const [ checkMonth, setCheckMonth ] = useState(false);
   const [ monthInfo, setMonthInfo ] = useState('');
 
@@ -82,8 +81,6 @@ export default function TransactionHistoryPage() {
   }
 
   const getTradeHistory = async () => {
-    // store에서 거래내역을 가져오기 (캐싱 지원)
-    await fetchTradeHistory();
     
     const end = toDateOnly(default_eTime);
     const start = toDateOnly(default_sTime);

--- a/src/app/investments/wait-orders/page.tsx
+++ b/src/app/investments/wait-orders/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import MarketListComponent from "@/components/MarketListComponent";
 import { apiClient } from "@/lib/apiClient";
+import { useAssetStore } from "@/store/assetStore";
 
 type PendingOrder = {
   uuid: string;
@@ -23,26 +24,8 @@ export default function WaitOrders() {
   const router = useRouter();
   const [orderType, setOrderType] = useState("전체주문");
   const [activeTab, setActiveTab] = useState("미체결");
-  const [orders, setOrders] = useState<PendingOrder[]>([]);
   const [selectedOrders, setSelectedOrders] = useState<Set<string>>(new Set()); // 선택된 주문 ID를 추적하는 Set
-
-  const fetchPendingOrders = async () => {
-  try {
-    const result = await apiClient.pendingOrders();
-    if (result !== 0) {
-      setOrders(result);
-    } else {
-      console.error("No pending orders found.");
-    }
-  } catch (error) {
-    console.error("Error fetching pending orders:", error);
-  }
-};
-
-
-  useEffect(() => {
-    fetchPendingOrders();
-  }, []);
+  const { pendingInfo } = useAssetStore();
 
   const tabs = ["거래내역", "미체결"];
 
@@ -56,7 +39,7 @@ export default function WaitOrders() {
   };
 
   // 주문 유형별 필터링 (전체, 매수, 매도)
-  const filteredOrders = orders.filter(order => {
+  const filteredOrders = pendingInfo.filter(order => {
     if (orderType === "전체주문") return true;
     if (orderType === "매수주문") return order.orderPosition === "BUY";
     if (orderType === "매도주문") return order.orderPosition === "SELL";
@@ -77,11 +60,6 @@ export default function WaitOrders() {
   // 일괄 취소 버튼 클릭 시
   const handleCancelSelectedOrders = () => {
     console.log("취소할 주문들: ", Array.from(selectedOrders));
-
-    // Remove the canceled orders from the 'orders' state
-    setOrders((prevOrders) =>
-      prevOrders.filter((order) => !selectedOrders.has(order.uuid))
-    );
 
     // Reset the selected orders set
     setSelectedOrders(new Set());

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css"
 import Header from "@/components/Header"
 import WebSocketProvider from "@/providers/WebSocketProvider"
 import Footer from "@/components/Footer"
+import ApiProvider from "@/providers/ApiProvider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -25,6 +26,7 @@ export default function RootLayout({
       <body className={`${inter.className} h-full`}>
         <WebSocketProvider>
           <div className="min-h-full">
+            <ApiProvider />
             <Header />
             <div className="pt-10">
               {children}

--- a/src/app/portfolio/holdings/page.tsx
+++ b/src/app/portfolio/holdings/page.tsx
@@ -19,7 +19,7 @@ export default function Holdings() {
   const [activeTab, setActiveTab] = useState("보유자산");
 
   const { tickers } = useMarketStore();
-  const { assets, fetchPortfolio, getDoughnutData, isLoading } = useAssetStore();
+  const { assets, getDoughnutData, isLoading } = useAssetStore();
 
   const [doughnutData, setDoughnutData] = useState<DoughnutData[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -30,21 +30,6 @@ export default function Holdings() {
     setActiveTab(tab);
     router.push(tab === "보유자산" ? '/portfolio/holdings' : '/portfolio/profit-loss');
   };
-
-  // 컴포넌트 마운트 시 portfolio 데이터 가져오기 (한 번만)
-  useEffect(() => {
-    const fetchData = async () => {
-      setError(null);
-      try {
-        await fetchPortfolio();
-      } catch (err: any) {
-        console.error("포트폴리오 데이터 불러오기 실패:", err);
-        setError(err.message || "데이터를 불러오는데 실패했습니다");
-      }
-    };
-
-    fetchData();
-  }, [fetchPortfolio]);
 
   // assets 혹은 tickers 변경 시 도넛 데이터 재계산
   useEffect(() => {

--- a/src/components/CandleChart.tsx
+++ b/src/components/CandleChart.tsx
@@ -21,12 +21,7 @@ const ChartComponent = createDynamicComponent(
 
 export const CandleChart = () => {
   const { candles, error, selected_time, timeUnit, isFetching, set_selectedTime, set_timeUnit, fetchAdditionCandles } = useCandleStore();
-  const { markets, initializeMarkets, selectedMarket } = useMarketStore();
-
-  // 마켓 초기화 (한 번만 실행)
-  useEffect(() => {
-    initializeMarkets();
-  }, [initializeMarkets]);
+  const { markets,  selectedMarket } = useMarketStore();
 
   // 데이터 가져오기 (의존성 최적화)
   useEffect(() => {

--- a/src/components/CryptoSummary.tsx
+++ b/src/components/CryptoSummary.tsx
@@ -52,10 +52,10 @@ export default function CryptoSummary() {
       try {
         // 마켓 정보 초기화
         await initializeMarkets();
-        // 초기 시세 데이터 로드
-        await loadInitialTickers();
         // WebSocket 연결
         await connect();
+        // 초기 시세 데이터 로드
+        await loadInitialTickers();
       } catch (error) {
         console.error('Initialization failed:', error);
       }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 import { apiClient } from '@/lib/apiClient';
+import { useAssetStore } from '@/store/assetStore';
 
 type LoginFormProps = {
   onSwitch?: () => void;
@@ -17,6 +18,7 @@ export default function LoginForm({ onSwitch }: LoginFormProps) {
   const { login } = useAuth();
   const router = useRouter();
   const setUser = useAuthStore((state) => state.setUser);
+  const { fetchPortfolio, fetchTradeHistory, fetchPending } = useAssetStore();
 
   const [ checkLogin, setCheckLogin ] = useState(false); // 로그인 실패 확인 변수
   const [ loginInfo, setLoginInfo ] = useState<string | undefined>();
@@ -29,6 +31,9 @@ export default function LoginForm({ onSwitch }: LoginFormProps) {
       const result = await login(username, passwd);
       if (result.success) {
         router.push('/'); // 메인 페이지로 리다이렉트
+        fetchPortfolio();
+        fetchTradeHistory();
+        fetchPending();
 
         try {
           const result = await apiClient.userInfo();

--- a/src/components/MarketList.tsx
+++ b/src/components/MarketList.tsx
@@ -49,12 +49,8 @@ export default function MarketList({ filterData }: MarketListProps) {
 
   // 마켓 선택 핸들러
   const handleMarketSelect = async (market: string) => {
-    await setSelectedMarket(market);
-    
-    // 현재 페이지가 exchange 페이지가 아닌 경우 exchange 페이지로 리디렉션
-    if (pathname !== '/exchange') {
-      router.push(`/exchange?market=${market}`);
-    }
+    // URL 변경 감지로만 setSelectedMarket()호출
+    router.push(`/exchange?market=${market}`);
   };
 
   if (isLoading && markets.length === 0) {

--- a/src/components/ProfitLoss.tsx
+++ b/src/components/ProfitLoss.tsx
@@ -30,7 +30,7 @@ export default function ProfitLossPage() {
   const tabs = ["보유자산", "투자손익"];
   const router = useRouter();
 
-  const { tradeHistory, fetchTradeHistory, isTradeHistoryLoading } = useAssetStore();
+  const { tradeHistory, isTradeHistoryLoading } = useAssetStore();
   const [chartData, setChartData] = useState<DataByDate[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Store 가져오기
@@ -113,11 +113,6 @@ export default function ProfitLossPage() {
       console.log(`계산된 데이터 ${dataByDate.length}개 생성`);
       return dataByDate;
     };
-
-    // 거래 내역 가져오기
-    useEffect(() => {
-      fetchTradeHistory();
-    }, [fetchTradeHistory]);
 
     // 거래 내역으로부터 차트 데이터 계산
       useEffect(() => {

--- a/src/components/ProfitLossNum.tsx
+++ b/src/components/ProfitLossNum.tsx
@@ -1,15 +1,13 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useAssetStore, TradeHistory } from '@/store/assetStore';
+import { useAssetStore } from '@/store/assetStore';
 import { useMarketStore } from '@/store/marketStore';
-import { apiClient } from '@/lib/apiClient';
 
 const ProfitSummary = () => {
   const tickers = useMarketStore(state => state.tickers);
   const { 
     getPeriodProfitLoss, 
-    fetchTradeHistory, 
     tradeHistory, 
     isTradeHistoryLoading 
   } = useAssetStore();
@@ -30,11 +28,6 @@ const ProfitSummary = () => {
       default: return 30;
     }
   };
-
-  // 거래내역 가져오기
-  useEffect(() => {
-    fetchTradeHistory();
-  }, [fetchTradeHistory]);
 
   // 기간별 손익 계산
   useEffect(() => {

--- a/src/providers/ApiProvider.tsx
+++ b/src/providers/ApiProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useAssetStore } from '@/store/assetStore';
+
+export default function ApiProvider() {
+  const { fetchTradeHistory, fetchPortfolio, fetchPending } = useAssetStore();
+  // 중복 fetch 방지
+  const hasFetchedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("auth-storage");
+    if (!stored) return;
+
+    try {
+      const parsed = JSON.parse(stored);
+      const isAuthenticated = parsed.state?.isAuthenticated;
+      console.log('isAuthenticated: ', isAuthenticated);
+      if (!isAuthenticated || hasFetchedRef.current) return;
+      fetchTradeHistory();
+      fetchPortfolio();
+      fetchPending();
+      hasFetchedRef.current = true;
+    } catch (err) {
+      console.error('Failed to Parsing: ', err);
+    }
+  }, []);
+
+  return null;
+}

--- a/src/store/marketStore.ts
+++ b/src/store/marketStore.ts
@@ -119,17 +119,17 @@ export const useMarketStore = create<MarketState>((set, get) => ({
     
     set({ isLoading: true });
     try {
-      const tickers = await fetchInitialTickers(markets);
-      const currentPrice = tickers[get().selectedMarket]?.trade_price || null;
+      // const tickers = await fetchInitialTickers(markets);
+      const currentPrice = get().tickers[get().selectedMarket]?.trade_price || null;
       
       set({ 
-        tickers, 
+ 
         currentPrice, 
         isLoading: false 
       });
       
-      console.log('Initial tickers loaded:', Object.keys(tickers).length, 'markets');
-      return tickers;
+      console.log('Initial tickers loaded:', Object.keys(get().tickers).length, 'markets');
+      return get().tickers;
     } catch (error) {
       set({ error: '초기 시세 데이터를 가져오는데 실패했습니다.', isLoading: false });
       return {};


### PR DESCRIPTION
- **upbit/market API  2번 호출 문제**
   -  candleChart에서, CryptoSummary에서 initializeMarkets()를 각각 한 번 씩 호출 
   -> candleChart에서 initializeMarkets() 호출 부분 삭제
- **upbit/tickers API  2번 호출 문제**
    - connect(), loadInitialTickers() 함수 둘 다 tickers API 호출 
    -> connect 함수에서 tickers를 호출 후 set을 하면 그 tickers를 loadInitialTickers 함수에서 사용하도록 수정
- **marketList에서 market 선택시 setSelectedMarket()이 2번 호출**
    - URL 변경 감지로만 setSelectedMarket() 호출
    -> upbit/trade API가 2번 호출되는 것을 1번 호출로 최적화
- **백엔드 API 호출 최적화( 로그인 성공, 처음 접속 시, 거래 성공 시에만 fetch한 후 zustand로 관리)**
    - 로그인이 안되어 있을 경우
    -> 로그인 성공 시 fetch
    - 로그인이 되어 있을 경우
    -> 접속 시 fetch
    - 거래 성공 하면 fetch